### PR TITLE
Add Docker Compose deployment and Nginx proxy examples

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+.git
+.github
+node_modules
+npm-debug.log
+*.log
+.env
+.env.local
+coverage

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,8 @@ COPY package.json package-lock.json ./
 RUN npm ci --omit=dev --ignore-scripts
 
 COPY --from=build /app/.smithery/shttp /app/.smithery/shttp
+RUN chown -R node:node /app
+USER node
 
 EXPOSE 8081
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,25 @@
+FROM node:20-bookworm-slim AS build
+
+WORKDIR /app
+
+COPY package.json package-lock.json ./
+RUN npm ci --ignore-scripts
+
+COPY . .
+RUN npm run build:shttp
+
+FROM node:20-bookworm-slim AS runtime
+
+WORKDIR /app
+
+ENV NODE_ENV=production
+ENV PORT=8081
+
+COPY package.json package-lock.json ./
+RUN npm ci --omit=dev --ignore-scripts
+
+COPY --from=build /app/.smithery/shttp /app/.smithery/shttp
+
+EXPOSE 8081
+
+CMD ["node", ".smithery/shttp/index.cjs"]

--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ Non-destructive actions like `flash_lights` / `honk` skip confirmation.
 - Run with Compose: `docker compose up --build`
 - The HTTP transport listens on `http://localhost:8081/mcp`
 - MCP config schema is available at `http://localhost:8081/.well-known/mcp-config`
+- Example Nginx reverse-proxy config (HTTPS + bearer auth translation): `deploy/nginx/tessie-mcp.conf`
+- Example MCP client configs (direct + via Nginx): `deploy/mcp-client-example.json`
 
 This containerization only wraps the existing shttp transport. Server configuration and authentication remain the same as the upstream project.
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,14 @@ Non-destructive actions like `flash_lights` / `honk` skip confirmation.
 - Tests: `npm test` (includes command validation)
 - Smoke with live Tessie token: `npm run smoke` (raw client), `npm run smoke:tools` (MCP tools)
 
+## Docker
+- Build the image: `docker build -t tessie-mcp-server .`
+- Run with Compose: `docker compose up --build`
+- The HTTP transport listens on `http://localhost:8081/mcp`
+- MCP config schema is available at `http://localhost:8081/.well-known/mcp-config`
+
+This containerization only wraps the existing shttp transport. Server configuration and authentication remain the same as the upstream project.
+
 ## Smithery
 - Playground/dev tunnel: `npm run dev` or `npx @smithery/cli dev`
 - Transports: stdio (`npm run build:stdio`), shttp (`npm run build:shttp`, default for publish)

--- a/deploy/mcp-client-example.json
+++ b/deploy/mcp-client-example.json
@@ -1,0 +1,30 @@
+{
+  "_comment": [
+    "Example MCP client configuration for tessie-mcp.",
+    "The server uses Smithery shttp transport — config values are passed as",
+    "query parameters (?accessToken=...) by the transport layer.",
+    "When running behind the provided Nginx reverse proxy, use bearer auth instead.",
+    "See deploy/nginx/tessie-mcp.conf for the proxy setup."
+  ],
+
+  "direct": {
+    "_comment": "Direct connection to the container (no Nginx). Token goes in the URL.",
+    "mcpServers": {
+      "tessie": {
+        "url": "http://localhost:8081/mcp?accessToken=YOUR_TESSIE_API_KEY"
+      }
+    }
+  },
+
+  "via_nginx": {
+    "_comment": "Connection through the Nginx reverse proxy. Token sent as a bearer header.",
+    "mcpServers": {
+      "tessie": {
+        "url": "https://YOUR_HOSTNAME:48378/mcp",
+        "headers": {
+          "Authorization": "Bearer YOUR_TESSIE_API_KEY"
+        }
+      }
+    }
+  }
+}

--- a/deploy/nginx/tessie-mcp.conf
+++ b/deploy/nginx/tessie-mcp.conf
@@ -1,0 +1,67 @@
+# Nginx reverse-proxy configuration for tessie-mcp
+#
+# This config sits in front of the tessie-mcp container (127.0.0.1:8081)
+# and translates a standard "Authorization: Bearer <token>" header into the
+# ?accessToken=<token> query parameter that the Smithery shttp transport expects.
+#
+# Ports (TESS on phone keypad = 8377):
+#   HTTP  → 48377  (redirects to HTTPS)
+#   HTTPS → 48378
+#
+# Usage:
+#   1. Copy or symlink to your Nginx sites-available/ directory.
+#   2. Replace the ssl_certificate / ssl_certificate_key paths.
+#   3. Set server_name to your hostname.
+#   4. Run: nginx -t && nginx -s reload
+#
+# The MCP client sends:
+#   POST https://<host>:48378/mcp
+#   Authorization: Bearer <your-tessie-api-key>
+#   mcp-session-id: <session-id>   (subsequent requests)
+
+# Redirect plain HTTP to HTTPS
+server {
+    listen 48377;
+    server_name YOUR_HOSTNAME;
+    return 301 https://$host:48378$request_uri;
+}
+
+server {
+    listen 48378 ssl;
+    server_name YOUR_HOSTNAME;
+
+    ssl_certificate     /path/to/cert.pem;
+    ssl_certificate_key /path/to/key.pem;
+
+    # Extract the bearer token from the Authorization header
+    set $tessie_token "";
+    if ($http_authorization ~* "^Bearer (.+)$") {
+        set $tessie_token $1;
+    }
+
+    # MCP endpoint — requires a valid bearer token
+    location /mcp {
+        if ($tessie_token = "") {
+            return 401 '{"jsonrpc":"2.0","error":{"code":-32600,"message":"\'Authorization: Bearer <YOUR_TESSIE_API_KEY>\' required"},"id":null}';
+        }
+
+        # Inject the token as the query param the shttp transport reads,
+        # and strip it from the forwarded Authorization header.
+        proxy_pass http://127.0.0.1:8081/mcp?accessToken=$tessie_token;
+        proxy_set_header Authorization "";
+        proxy_set_header Host $host;
+
+        # Forward the session-id header for stateful MCP sessions
+        proxy_set_header mcp-session-id $http_mcp_session_id;
+
+        proxy_http_version 1.1;
+        proxy_read_timeout 300s;
+    }
+
+    # Well-known discovery endpoint — no auth required
+    location /.well-known/ {
+        proxy_pass http://127.0.0.1:8081;
+        proxy_set_header Host $host;
+        proxy_http_version 1.1;
+    }
+}

--- a/deploy/nginx/tessie-mcp.conf
+++ b/deploy/nginx/tessie-mcp.conf
@@ -45,9 +45,10 @@ server {
             return 401 '{"jsonrpc":"2.0","error":{"code":-32600,"message":"\'Authorization: Bearer <YOUR_TESSIE_API_KEY>\' required"},"id":null}';
         }
 
+        access_log off;
         # Inject the token as the query param the shttp transport reads,
         # and strip it from the forwarded Authorization header.
-        proxy_pass http://127.0.0.1:8081/mcp?accessToken=$tessie_token;
+        proxy_pass http://127.0.0.1:8081/mcp?accessToken=$tessie_token&$args;
         proxy_set_header Authorization "";
         proxy_set_header Host $host;
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,16 @@
+services:
+  tessie-mcp:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    environment:
+      PORT: 8081
+    ports:
+      - "127.0.0.1:8081:8081"
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://127.0.0.1:8081/.well-known/mcp-config >/dev/null || exit 1"]
+      interval: 30s
+      timeout: 5s
+      retries: 5
+      start_period: 15s
+    restart: unless-stopped


### PR DESCRIPTION
## Summary
This PR adds optional containerized deployment support for tessie-mcp without changing core MCP server behavior.

## What Changed
- Added Dockerfile with a multi-stage build for the Smithery shttp transport.
- Added docker-compose.yml with:
  - service definition for tessie-mcp
  - healthcheck on the well-known MCP config endpoint
  - restart policy for resilience
- Added .dockerignore to keep Docker build contexts smaller and cleaner.
- Added deployment examples:
  - tessie-mcp.conf showing bearer-header to query-parameter translation for shttp behind Nginx
  - mcp-client-example.json showing direct and Nginx-proxied MCP client configuration
- Updated README.md with a concise Docker usage section.

## Behavior / Compatibility
- No changes to application tool logic or Tessie API integration behavior.
- Existing auth/config behavior remains the same as upstream (accessToken-based config for shttp sessions).
- Docker and Nginx examples are optional deployment paths only.

## Validation
- Docker image builds successfully.
- Container starts and serves:
  - MCP endpoint at /mcp
  - config discovery endpoint at mcp-config
- End-to-end initialize flow verified through both direct container access and Nginx reverse proxy setup.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add containerization support: image + Compose service to run locally (binds to 127.0.0.1:8081) with healthchecks.

* **Documentation**
  * README now includes Docker build/run instructions and corrected example endpoints.
  * Add example client configuration and a reverse-proxy template for token forwarding and TLS.

* **Chores**
  * Add Docker build ignore rules to reduce build context.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->